### PR TITLE
Make containers boxes in about us page consistent with other pages in…

### DIFF
--- a/about-us-page.html
+++ b/about-us-page.html
@@ -47,7 +47,7 @@
     <h1 class="about-us-title">About Us Page</h1>
 
     <section class="about-us-intro box">
-      <img class="about-us-image" src="./assets/images/thunderbolts_photo.jpeg" alt="group photo of thunderbolt members"
+      <img class="about-us-image" src="./assets/images/thunderbolts-group-poster.jpg" alt="group photo of thunderbolt members"
         style="height: auto;">
       <div class="intro-wrapper">
         <h2 class="about-us-subheading">First of all, we want to be called as Team Thunderbolts</h2>

--- a/styles/about-us-page.css
+++ b/styles/about-us-page.css
@@ -1,13 +1,9 @@
-.box {
-  max-width: calc(100% - 60px);
-}
-
 .about-us-intro {
   align-items: center;
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  margin: 0rem 2rem;
+  margin: 0rem auto;
 }
 
 .about-us-image {
@@ -36,15 +32,20 @@
   flex-wrap: wrap;
   gap: 0.5rem;
   justify-content: space-between;
-  margin: 1.5rem;
+  margin: 0 auto 40px;
 }
 
 .about-us-contents {
+  background: var(--box-background-color);
+  border-radius: 12px;
   border: 2px solid #606C38;
+  box-shadow: var(--box-shadow-color);
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+  max-width: 800px;
   padding: 1rem;
+  width: 100%;
 }
 
 .about-us-contents img,
@@ -131,12 +132,21 @@ p {
 }
 
 @media only screen and (min-width:769px) {
+  .box {
+    max-width: calc(100% - 60px);
+  }
+
   .about-us-intro {
     flex-direction: row;
+    margin: 0rem 2rem;
   }
 
   .about-us-image {
     width: 50%;
+  }
+
+  .about-us-section {
+    margin: 1.5rem;
   }
 
   .about-us-contents {


### PR DESCRIPTION
Make the containing boxes of each sections in about us page consistent with the other pages on mobile version
Make the appropriate changes in css regarding desktop and mobile versions
Add the background color and box shadow on about us contents boxes
Test on both mobile and desktop